### PR TITLE
Fix Streamlit config file location

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,3 @@
-## .streamlit/config.toml:
-```toml
 [theme]
 primaryColor = "#1f77b4"
 backgroundColor = "#ffffff"
@@ -14,4 +12,3 @@ maxUploadSize = 200
 
 [browser]
 gatherUsageStats = false
-```


### PR DESCRIPTION
## Summary
- fix Streamlit config formatting and place in `.streamlit/config.toml`

## Testing
- `streamlit run app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81a894ca88327810cd68f595a9fca